### PR TITLE
vyatta-op-vpn: prevent invalid rsa key file from being generated & display the config path location for the rsa key file

### DIFF
--- a/scripts/gen_local_rsa_key.pl
+++ b/scripts/gen_local_rsa_key.pl
@@ -85,6 +85,21 @@ if (-r $local_key_file) {
     }
 }
 
+# Remove the temporary file used to hold the new key if it already exists
+# as this can cause invalid key generation if a previous run has been
+# aborted.
+
+my $temp_key_file = $local_key_file.".new";
+
+if (-e $temp_key_file) {
+    $cmd = "rm $temp_key_file";
+    vpn_debug $cmd;
+    $rc = system($cmd);
+    if ($rc != 0) {
+        die "Cannot remove temporary key file $!\n";
+    }
+}
+
 $cmd = "/usr/lib/ipsec/newhostkey --output $local_key_file --bits $bits";
 #
 # The default random number generator is /dev/random, but it will block 

--- a/scripts/vyatta-show-vpn.pl
+++ b/scripts/vyatta-show-vpn.pl
@@ -27,6 +27,7 @@ use strict;
 use warnings;
 
 use lib "/opt/vyatta/share/perl5/";
+use Vyatta::Misc qw(get_short_config_path);
 
 my $arg0 = $ARGV[0];
 if (!defined($arg0)) {
@@ -82,10 +83,11 @@ if ($arg0 eq 'rsa-keys') {
         die "No key file $key_file found.\n";
     }
     my $pubkey = rsa_get_local_pubkey($key_file);
+    my $config_key_file = get_short_config_path($key_file);
     if ($pubkey eq 0) {
 	die "No local pubkey found.\n";
     }
-    print "\nLocal public key ($key_file):\n\n$pubkey\n\n";
+    print "\nLocal public key ($config_key_file):\n\n$pubkey\n\n";
 
     use Vyatta::Config;
     my $vc = new Vyatta::Config();


### PR DESCRIPTION
vyatta-op-vpn: prevent invalid rsa key file from being generated

If the command "generate vpn rsa-key" is aborted during key generation
it leaves behind a temporary file.  If the command is then executed
again, this temporary file is appended to rather than being replaced,
resulting in a key file with an extra : RSA { line at the beginning.

This patch checks if this temporary file exists, deleting it if it
does.

Bug #262 http://bugzilla.vyos.net/show_bug.cgi?id=262

vyatta-op-vpn: display the config path location for the rsa key file

The command "show vpn ike rsa-keys" currently displays the full system
file path rather than using the shorter config path.  This sets it to
display the config path instead.

Bug #278 http://bugzilla.vyos.net/show_bug.cgi?id=278
