### PR TITLE
Fix detection of IKEv2 IKE DH Group

### DIFF
--- a/lib/OPMode.pm
+++ b/lib/OPMode.pm
@@ -590,10 +590,10 @@ sub process_tunnels{
 
         $tunnel_hash{$connectid}->{_ikestate} = "up" if ($atime >= 0);
 
-      } elsif ($line =~ /\]:\s+IKE.proposal:(.*?)\/(.*?)\/(.*)/) {
+      } elsif ($line =~ /\]:\s+IKE.proposal:(.*?)\/(.*?)\/(.*?)\/(.*)/) {
         $tunnel_hash{$connectid}->{_ikeencrypt} = $1;
         $tunnel_hash{$connectid}->{_ikehash} = $2;
-        $tunnel_hash{$connectid}->{_dhgrp} = $3;
+        $tunnel_hash{$connectid}->{_dhgrp} = $4;
       
       } elsif ($line =~ /{(\d+)}:\s+INSTALLED.*ESP.*SPIs: (.*)_i (.*)_o/) {
         $esp_hash{$connectid}{$1}->{_inspi} = $2;


### PR DESCRIPTION
Bug: http://bugzilla.vyos.net/show_bug.cgi?id=402

Fixing detection of DH Group in output of "show vpn ike sa"
