### PR TITLE
Explicitly close the IPSECCONF pipe

### DIFF
--- a/lib/OPMode.pm
+++ b/lib/OPMode.pm
@@ -695,6 +695,7 @@ sub get_conns
   while(<$IPSECCONF>){
     push (@ipsecconf, $_);
   }
+  close($IPSECCONF);
   my %th = ();
   for my $line (@ipsecconf){
     next if ($line =~/^\#/);


### PR DESCRIPTION
This should avoid problems when `cat` commands finishes, but `sudo` doesn't.
