### PR TITLE
Migration Script for transitioning out of non-dfsg filesystem space

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,7 @@ libtool
 /config.sub
 /configure
 /debian/files
-/debian/vyatta-op-vpn
-/debian/vyatta-op-vpn.postinst
+/debian/vyatta-op-vpn/
 /debian/vyatta-op-vpn.debhelper.log
 /debian/vyatta-op-vpn.substvars
 /INSTALL

--- a/debian/autogen.sh
+++ b/debian/autogen.sh
@@ -4,7 +4,6 @@
 rm -rf config
 rm -f aclocal.m4 config.guess config.statusconfig.sub configure INSTALL
 
-mkdir -p
 autoreconf --force --install
 
 rm -f config.sub config.guess

--- a/debian/vyatta-op-vpn.postinst
+++ b/debian/vyatta-op-vpn.postinst
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -e
+
+case "$1" in
+    configure)
+	if [ -d /opt/vyatta ]
+	then
+	    for file in $(dpkg -L vyatta-op-vpn)
+	    do
+		DFSG_PATH=${file}
+		OPT_PATH=$(echo ${file} | sed -e 's:/usr:/opt/vyatta:')
+		test -d ${DFSG_PATH} && mkdir -p ${OPT_PATH}
+		test -f ${DFSG_PATH} && ln -sf ${DFSG_PATH} ${OPT_PATH}
+	    done
+	fi
+    ;;
+    abort-upgrade|abort-remove|abort-deconfigure)
+    ;;
+    *)
+        echo "postinst called with unknown argument \`$1'" >&2
+        exit 1
+    ;;
+esac
+
+#DEBHELPER#


### PR DESCRIPTION
- Considering that constraining one's self to the DFSG acceptable
  install directories is generally considered to be a good thing for
  numerous reasons discussed ad nausium in committees, I hereby offer
  this Migration Script for those who wish to install packages from
  security.debian.org on vyos installations which exist in the legacy
  install directory.

Signed-off-by: C.J. Collier cjcollier@linuxfoundation.org
