### PR TITLE
Two fixes - for T319 and T303

### DIFF
--- a/lib/OPMode.pm
+++ b/lib/OPMode.pm
@@ -837,8 +837,8 @@ sub get_connection_status
     (my $peerid, my $tun) = @_;
     my %th = get_tunnel_info_peer($peerid);
     for my $peer ( keys %th ) {
-      if (%{$th{$peer}}->{_tunnelnum} eq $tun){
-        return %{$th{$peer}}->{_state};
+      if (${$th{$peer}}{_tunnelnum} eq $tun){
+        return ${$th{$peer}}{_state};
       }
     }
 }
@@ -847,10 +847,10 @@ sub get_peer_ike_status
     my ($peerid) = @_;
     my %th = get_tunnel_info_peer($peerid);
     for my $peer ( keys %th ) {
-      if (%{$th{$peer}}->{_ikestate} eq 'up'){
+      if (${$th{$peer}}{_ikestate} eq 'up'){
         return 'up';    
       }
-      if (%{$th{$peer}}->{_ikestate} eq 'init'){
+      if (${$th{$peer}}{_ikestate} eq 'init'){
         return 'init';    
       }
     }
@@ -862,7 +862,7 @@ sub show_ipsec_sa_natt
     my %tunnel_hash = get_tunnel_info();
     my %tmphash = ();
     for my $peer ( keys %tunnel_hash ) {
-       if (%{$tunnel_hash{$peer}}->{_natt} == 1 ){
+       if (${$tunnel_hash{$peer}>{_natt} == 1 ){
          $tmphash{$peer} = \%{$tunnel_hash{$peer}};
        }
     }
@@ -905,7 +905,7 @@ sub show_ike_sa_natt
     my %tunnel_hash = get_tunnel_info();
     my %tmphash = ();
     for my $peer ( keys %tunnel_hash ) {
-      if (%{$tunnel_hash{$peer}}->{_natt} == 1 ){
+      if (${$tunnel_hash{$peer}}{_natt} == 1 ){
         $tmphash{$peer} = \%{$tunnel_hash{$peer}};
       }
     }

--- a/scripts/vyatta-show-ipsec-status.pl
+++ b/scripts/vyatta-show-ipsec-status.pl
@@ -98,7 +98,10 @@ sub relate_intfs_with_localips {
 #
 
 my $process_id = `sudo cat /var/run/charon.pid`;
-my $active_tunnels = `sudo ipsec status 2>/dev/null | grep 'newest IPsec SA: #' | grep -v 'newest IPsec SA: #0' | wc -l`;
+# Update to deal with new strongswan syntax for ipsec status command.
+my $sa_summary = `sudo ipsec status 2>/dev/null | grep "Security Associations" `;
+my $active_tunnels;
+($active_tunnels) = $sa_summary =~ /\((.*?) up/;
 chomp $process_id;
 chomp $active_tunnels;
 my @vpn_interfaces = get_vpn_intfs();


### PR DESCRIPTION
Nothing earth shattering - one to do with changed strongswan behaviour, and one to do with more modern perl semantics.

