### PR TITLE
Fixes for show vpn ike sa and show vpn ipsec sa

### DIFF
--- a/templates/show/vpn/ipsec/sa/node.def
+++ b/templates/show/vpn/ipsec/sa/node.def
@@ -1,6 +1,6 @@
 help: Show all active IPsec Security Associations (SA)
 run: if pgrep charon >&/dev/null; then
-        sudo /usr/sbin/swanctl --list-sas
+        sudo /opt/vyatta/bin/sudo-users/vyatta-op-vpn.pl --show-ipsec-sa
      else
         echo -e "IPSec Process NOT Running\n"
      fi


### PR DESCRIPTION
Heya. This is an additional pull request against T346. Two minor tweaks - one wiring, and one to deal with the case where an Phase 1 connection wasn't actually up - 'show vpn ike sa' would previously not return any information at all.


Fixed 'show vpn ike sa' to actually show output when the tunnel isn't up.

Fixed 'show vpn ipsec sa' to actually use the pretty-printing code, rather than swanctl --list-sas, which is pretty unpleasant.