### PR TITLE
T3380: fix show vpn ike sa with IPv6 Peers

### DIFF
--- a/lib/OPMode.pm
+++ b/lib/OPMode.pm
@@ -33,7 +33,7 @@ sub conv_id {
   my $peer = pop(@_);
   if ( $peer =~ /\d+\.\d+\.\d+\.\d+/ ){
     $peer = $peer;
-  } elsif ($peer =~ /\d+\:\d+\:\d+\:\d+\:\d+\:\d+\:\d+\:\d+/){
+  } elsif ($peer =~ /([A-Fa-f0-9]+)\:([A-Fa-f0-9]+)\:([A-Fa-f0-9]+)\:([A-Fa-f0-9]+)\:([A-Fa-f0-9]+)\:([A-Fa-f0-9]+)\:([A-Fa-f0-9]+)\:([A-Fa-f0-9]+)\:/){
     $peer = $peer;
   } elsif ($peer =~ /\%any/){
     $peer = "any";


### PR DESCRIPTION
IPv6 regex is not only made up of digits
This change allows a correct display of the command 'show vpn ike sa' with IPv6 remote peer