### PR TITLE
vpn: T1995: Fix op-mode for ike sa

### DIFF
--- a/lib/OPMode.pm
+++ b/lib/OPMode.pm
@@ -1281,7 +1281,7 @@ sub display_ike_sa_brief {
       my $lip = $th{$connectid}->{_lip};
       $peerid = $th{$connectid}->{_rip};
       my $tunnel = "$peerid-$lip";
-      #next if ($th{$connectid}->{_ikestate} eq 'down');
+      next if ($th{$connectid}->{_ikestate} eq 'down' && $th{$connectid}->{_ikever} eq 'n/a');
       if (not exists $tunhash{$tunnel}) {
         $tunhash{$tunnel}={
           _configpeer => conv_id_rev($th{$connectid}->{_peerid}),


### PR DESCRIPTION
Fix for "show vpn ike sa"
It show's the wrong values for child_SA's. All child_SA's use IKE parent state, that the same for all child.
Add additional check's it connection "down" and ike version " n/a" (not match real IKE connection) then it needs to exclude from "output"

Task https://phabricator.vyos.net/T1995

Output for ipsec sa
We have 3 peers | 3 IKE sa. One IKE works and 2 not works.

```
vyos@r6-roll:~$ show vpn ipsec sa
Connection                State    Uptime    Bytes In/Out    Packets In/Out    Remote address    Remote ID    Proposal
------------------------  -------  --------  --------------  ----------------  ----------------  -----------  ----------------------------------
peer-100.64.0.2-tunnel-1  up       26m13s    0B/0B           0/0               100.64.0.2        N/A          AES_CBC_256/HMAC_SHA1_96/MODP_1024
peer-100.64.0.2-tunnel-2  up       26m13s    0B/0B           0/0               100.64.0.2        N/A          AES_CBC_256/HMAC_SHA1_96/MODP_1024
peer-100.64.0.2-tunnel-3  up       26m13s    0B/0B           0/0               100.64.0.2        N/A          AES_CBC_256/HMAC_SHA1_96/MODP_1024
peer-100.64.0.2-tunnel-4  up       26m13s    0B/0B           0/0               100.64.0.2        N/A          AES_CBC_256/HMAC_SHA1_96/MODP_1024
peer-100.64.0.2-tunnel-5  up       26m13s    0B/0B           0/0               100.64.0.2        N/A          AES_CBC_256/HMAC_SHA1_96/MODP_1024
peer-100.64.0.2-tunnel-6  up       26m13s    0B/0B           0/0               100.64.0.2        N/A          AES_CBC_256/HMAC_SHA1_96/MODP_1024
peer-100.64.0.2-tunnel-7  up       26m13s    0B/0B           0/0               100.64.0.2        N/A          AES_CBC_256/HMAC_SHA1_96/MODP_1024
peer-100.64.0.5-tunnel-0  down     N/A       N/A             N/A               N/A               N/A          N/A
peer-100.64.0.7-tunnel-0  down     N/A       N/A             N/A               N/A               N/A          N/A

```
Output for IKE without fix
```
vyos@r6-roll:~$ show vpn ike sa
Peer ID / IP                            Local ID / IP               
------------                            -------------
n/a                                     100.64.0.1                             

    State  IKEVer  Encrypt  Hash    D-H Group      NAT-T  A-Time  L-Time
    -----  ------  -------  ----    ---------      -----  ------  ------
    down   N/A     n/a      n/a     n/a(n/a)       no     0       n/a    
    down   N/A     n/a      n/a     n/a(n/a)       no     0       n/a    
    down   N/A     n/a      n/a     n/a(n/a)       no     0       n/a    
    down   N/A     n/a      n/a     n/a(n/a)       no     0       n/a    
    down   N/A     n/a      n/a     n/a(n/a)       no     0       n/a    
    down   N/A     n/a      n/a     n/a(n/a)       no     0       n/a    

 
Peer ID / IP                            Local ID / IP               
------------                            -------------
100.64.0.2                              100.64.0.1                             

    State  IKEVer  Encrypt  Hash    D-H Group      NAT-T  A-Time  L-Time
    -----  ------  -------  ----    ---------      -----  ------  ------
    up     IKEv1   aes256   sha1_96 2(MODP_1024)   no     1080    3600   

 
Peer ID / IP                            Local ID / IP               
------------                            -------------
100.64.0.5                              100.64.0.1                             

    State  IKEVer  Encrypt  Hash    D-H Group      NAT-T  A-Time  L-Time
    -----  ------  -------  ----    ---------      -----  ------  ------
    down   IKEv1   n/a      n/a     n/a(n/a)       no     0       n/a    

 
Peer ID / IP                            Local ID / IP               
------------                            -------------
100.64.0.7                              100.64.0.1                             

    State  IKEVer  Encrypt  Hash    D-H Group      NAT-T  A-Time  L-Time
    -----  ------  -------  ----    ---------      -----  ------  ------
    down   IKEv2   n/a      n/a     n/a(n/a)       no     0       n/a    


```


Fixed output for IKE sa
```
vyos@r6-roll:~$ show vpn ike sa
Peer ID / IP                            Local ID / IP               
------------                            -------------
100.64.0.2                              100.64.0.1                             

    State  IKEVer  Encrypt  Hash    D-H Group      NAT-T  A-Time  L-Time
    -----  ------  -------  ----    ---------      -----  ------  ------
    up     IKEv1   aes256   sha1_96 2(MODP_1024)   no     2460    3600   

 
Peer ID / IP                            Local ID / IP               
------------                            -------------
100.64.0.5                              100.64.0.1                             

    State  IKEVer  Encrypt  Hash    D-H Group      NAT-T  A-Time  L-Time
    -----  ------  -------  ----    ---------      -----  ------  ------
    down   IKEv1   n/a      n/a     n/a(n/a)       no     0       n/a    

 
Peer ID / IP                            Local ID / IP               
------------                            -------------
100.64.0.7                              100.64.0.1                             

    State  IKEVer  Encrypt  Hash    D-H Group      NAT-T  A-Time  L-Time
    -----  ------  -------  ----    ---------      -----  ------  ------
    down   IKEv2   n/a      n/a     n/a(n/a)       no     0       n/a    

 
vyos@r6-roll:~$ 

```

