### PR TITLE
ipsec-op: T3341: Fix for resetting peer tunnel

### DIFF
--- a/scripts/vyatta-vpn-op.pl
+++ b/scripts/vyatta-vpn-op.pl
@@ -48,7 +48,7 @@ sub clear_tunnel {
   print "Resetting tunnel $tunnel with peer $peer...\n";
   
   # bring down the tunnel
-  `sudo /usr/sbin/ipsec down peer-$peer-tunnel-$tunnel`;
+  `sudo /usr/sbin/ipsec down peer-$peer-tunnel-$tunnel\{\*\}`;
   # bring up the tunnel
   `sudo /usr/sbin/ipsec up peer-$peer-tunnel-$tunnel`;
 }


### PR DESCRIPTION
## Change Summary
The current resetting is affected for parent SA, in that case
all child SA's are resetting (if one peer have a several tunnels)
This commit fixes such behavior for correct resetting child SA's.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3341

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vpn

## How to test
Configure peer with more than 1 tunnel and reset ipsec tunnel 0

```
vyos@r4-epa2:~$ reset vpn ipsec-peer 192.0.2.2 tunnel 0
Resetting tunnel 0 with peer 192.0.2.2...
vyos@r4-epa2:~$ 
```
Check that only tunnel 0 was reset:
```
peer-192.0.2.2-tunnel-0: #1, ESTABLISHED, IKEv1, e49e5b247597c265_i* 02a81d10d8ca795f_r
  local  '192.0.2.1' @ 192.0.2.1[500]
  remote '192.0.2.2' @ 192.0.2.2[500]
  AES_CBC-256/HMAC_SHA1_96/PRF_HMAC_SHA1/MODP_1024
  established 665s ago, reauth in 2205s
  peer-192.0.2.2-tunnel-1: #3, reqid 3, INSTALLED, TUNNEL, ESP:AES_CBC-256/HMAC_SHA1_96/MODP_1024
    installed 665s ago, rekeying in 424s, expires in 1135s
    in  c1164c47,      0 bytes,     0 packets
    out cc564a00,      0 bytes,     0 packets
    local  10.1.2.0/24
    remote 10.2.2.0/24
  peer-192.0.2.2-tunnel-2: #4, reqid 4, INSTALLED, TUNNEL, ESP:AES_CBC-256/HMAC_SHA1_96/MODP_1024
    installed 665s ago, rekeying in 321s, expires in 1135s
    in  c39761d6,      0 bytes,     0 packets
    out c1d62b31,      0 bytes,     0 packets
    local  10.1.3.0/24
    remote 10.2.3.0/24
  peer-192.0.2.2-tunnel-0: #6, reqid 6, INSTALLED, TUNNEL, ESP:AES_CBC-256/HMAC_SHA1_96/MODP_1024
    installed 27s ago, rekeying in 831s, expires in 1773s
    in  c3d4fd3f,      0 bytes,     0 packets
    out cef6a3c7,      0 bytes,     0 packets
    local  10.1.1.0/24
    remote 10.2.1.0/24

```

Before fix:
```
vyos@r4-epa2:~$ sudo /usr/sbin/ipsec down peer-192.0.2.2-tunnel-0
closing CHILD_SA peer-192.0.2.2-tunnel-0{1} with SPIs c9e3be8e_i (0 bytes) c576f903_o (0 bytes) and TS 10.1.1.0/24 === 10.2.1.0/24
sending DELETE for ESP CHILD_SA with SPI c9e3be8e
generating INFORMATIONAL_V1 request 3204779330 [ HASH D ]
sending packet: from 192.0.2.1[500] to 192.0.2.2[500] (76 bytes)
closing CHILD_SA peer-192.0.2.2-tunnel-1{2} with SPIs c17a6bd8_i (0 bytes) cbbdb752_o (0 bytes) and TS 10.1.2.0/24 === 10.2.2.0/24
sending DELETE for ESP CHILD_SA with SPI c17a6bd8
generating INFORMATIONAL_V1 request 3529486115 [ HASH D ]
sending packet: from 192.0.2.1[500] to 192.0.2.2[500] (76 bytes)
closing CHILD_SA peer-192.0.2.2-tunnel-2{3} with SPIs cd1d0863_i (0 bytes) c28e7d28_o (0 bytes) and TS 10.1.3.0/24 === 10.2.3.0/24
sending DELETE for ESP CHILD_SA with SPI cd1d0863
generating INFORMATIONAL_V1 request 873539475 [ HASH D ]
sending packet: from 192.0.2.1[500] to 192.0.2.2[500] (76 bytes)
closing CHILD_SA peer-192.0.2.2-tunnel-1{4} with SPIs c3322207_i (0 bytes) ce5a1f6e_o (0 bytes) and TS 10.1.2.0/24 === 10.2.2.0/24
sending DELETE for ESP CHILD_SA with SPI c3322207
generating INFORMATIONAL_V1 request 4222424244 [ HASH D ]
sending packet: from 192.0.2.1[500] to 192.0.2.2[500] (76 bytes)
closing CHILD_SA peer-192.0.2.2-tunnel-2{5} with SPIs c60e0588_i (0 bytes) cc251e07_o (0 bytes) and TS 10.1.3.0/24 === 10.2.3.0/24
sending DELETE for ESP CHILD_SA with SPI c60e0588
generating INFORMATIONAL_V1 request 1532604798 [ HASH D ]
sending packet: from 192.0.2.1[500] to 192.0.2.2[500] (76 bytes)
deleting IKE_SA peer-192.0.2.2-tunnel-0[1] between 192.0.2.1[192.0.2.1]...192.0.2.2[192.0.2.2]
sending DELETE for IKE_SA peer-192.0.2.2-tunnel-0[1]
generating INFORMATIONAL_V1 request 4135162887 [ HASH D ]
sending packet: from 192.0.2.1[500] to 192.0.2.2[500] (92 bytes)
IKE_SA [1] closed successfully
vyos@r4-epa2:~$ 
```
After fix
```
vyos@r4-epa2:~$ sudo /usr/sbin/ipsec down peer-192.0.2.2-tunnel-0\{\*\}
closing CHILD_SA peer-192.0.2.2-tunnel-0{18} with SPIs c4ad8b48_i (0 bytes) c084b5c1_o (0 bytes) and TS 10.1.1.0/24 === 10.2.1.0/24
sending DELETE for ESP CHILD_SA with SPI c4ad8b48
generating INFORMATIONAL_V1 request 1059006425 [ HASH D ]
sending packet: from 192.0.2.1[500] to 192.0.2.2[500] (76 bytes)
CHILD_SA {18} closed successfully
vyos@r4-epa2:~$ 
```