### PR TITLE
ipsec-op: T3341: Fix for resetting peer tunnel

### DIFF
--- a/scripts/vyatta-vpn-op.pl
+++ b/scripts/vyatta-vpn-op.pl
@@ -48,7 +48,7 @@ sub clear_tunnel {
   print "Resetting tunnel $tunnel with peer $peer...\n";
   
   # bring down the tunnel
-  `sudo /usr/sbin/ipsec down peer-$peer-tunnel-$tunnel`;
+  `sudo /usr/sbin/ipsec down peer-$peer-tunnel-$tunnel\{\*\}`;
   # bring up the tunnel
   `sudo /usr/sbin/ipsec up peer-$peer-tunnel-$tunnel`;
 }


### PR DESCRIPTION
## Change Summary
VyOS 1.2
The current resetting is affected for parent SA, in that case
all child SA's are resetting (if one peer have a several tunnels)
This commit fixes such behavior for correct resetting child SA's.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3341

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vpn

## How to test
Configure peer with more than 1 tunnel and reset ipsec tunnel 0

```
vyos@r12-lts:~$ reset vpn ip
ipsec-peer     ipsec-profile  
vyos@r12-lts:~$ reset vpn ipsec-peer 192.0.2.1 tunnel 0
Resetting tunnel 0 with peer 192.0.2.1...
vyos@r12-lts:~$ 

```
Check that only tunnel 0 was reset:
```
vyos@r12-lts:~$ sudo swanctl -l
peer-192.0.2.1-tunnel-0: #1, ESTABLISHED, IKEv1, 2667703e29fa2fc6_i* bd71dc68a6d64e59_r
  local  '192.0.2.2' @ 192.0.2.2[500]
  remote '192.0.2.1' @ 192.0.2.1[500]
  AES_CBC-256/HMAC_SHA1_96/PRF_HMAC_SHA1/MODP_1024
  established 167s ago, reauth in 2677s
  peer-192.0.2.1-tunnel-1: #5, reqid 2, INSTALLED, TUNNEL, ESP:AES_CBC-256/HMAC_SHA1_96/MODP_1024
    installed 167s ago, rekeying in 605s, expires in 1633s
    in  c8d7a4ef,      0 bytes,     0 packets
    out c35351b1,      0 bytes,     0 packets
    local  10.1.2.0/24
    remote 10.2.2.0/24
  peer-192.0.2.1-tunnel-2: #6, reqid 3, INSTALLED, TUNNEL, ESP:AES_CBC-256/HMAC_SHA1_96/MODP_1024
    installed 167s ago, rekeying in 559s, expires in 1633s
    in  c8feb502,      0 bytes,     0 packets
    out ca5330a6,      0 bytes,     0 packets
    local  10.1.3.0/24
    remote 10.2.3.0/24
  peer-192.0.2.1-tunnel-0: #7, reqid 4, INSTALLED, TUNNEL, ESP:AES_CBC-256/HMAC_SHA1_96/MODP_1024
    installed 4s ago, rekeying in 815s, expires in 1796s
    in  c4637883,      0 bytes,     0 packets
    out c2d867ac,      0 bytes,     0 packets
    local  10.1.1.0/24
    remote 10.2.1.0/24

```
