### PR TITLE
vpn-op: T3846: Fix for restart vpn with nhrp config

### DIFF
--- a/scripts/vyatta-vpn-op.pl
+++ b/scripts/vyatta-vpn-op.pl
@@ -62,6 +62,11 @@ if ($op eq 'clear-vpn-ipsec-process') {
   my $update_interval = `cli-shell-api returnActiveValue vpn ipsec auto-update`;
   if ($update_interval eq ''){
 	  system 'sudo /usr/sbin/ipsec restart >&/dev/null';
+          # Check if nhrp configuration exists, exit code
+          # As 'restart vpn' doesn't load nhrp configuration T3846
+          if (system('cli-shell-api existsActive protocols nhrp') == 0) {
+              system 'sudo swanctl --load-all';
+          }
   } else {
     system 'sudo /usr/sbin/ipsec restart --auto-update '.$update_interval.' >&/dev/null';
   }


### PR DESCRIPTION
After command "restart vpn" nhrp/IPSec configuration not loaded
Add checks if nhrp exist in the configuration and help to load it
via swanctl.

* https://phabricator.vyos.net/T3846

Configure nhrp/IPSec, Reset VPN from op-mode
In swanctl -L we should see loaded dmvpn configuration entries:
```
vyos@r4-epa2:~$ restart vpn 
Restarting IPsec process...
loaded ike secret 'ike-dmvpn-tun0'
no authorities found, 0 unloaded
no pools found, 0 unloaded
loaded connection 'dmvpn-NHRPVPN-tun0'
successfully loaded 1 connections, 0 unloaded
vyos@r4-epa2:~$ 
vyos@r4-epa2:~$ sudo swanctl -L
dmvpn-NHRPVPN-tun0: IKEv1, reauthentication every 3600s
  local:  %any
  remote: %any
  local pre-shared key authentication:
  remote pre-shared key authentication:
  dmvpn: TRANSPORT, rekeying every 1800s
    local:  dynamic[gre]
    remote: dynamic[gre]
vyos@r4-epa2:~$ 

```