### PR TITLE
vpn: T3380: Fix for op-mode regex for IPv6 IPSec IKE sa

### DIFF
--- a/lib/OPMode.pm
+++ b/lib/OPMode.pm
@@ -33,7 +33,7 @@ sub conv_id {
   my $peer = pop(@_);
   if ( $peer =~ /\d+\.\d+\.\d+\.\d+/ ){
     $peer = $peer;
-  } elsif ($peer =~ /\d+\:\d+\:\d+\:\d+\:\d+\:\d+\:\d+\:\d+/){
+  } elsif ($peer =~ /([a-f0-9\:]+\:+)+[a-f0-9]+/){
     $peer = $peer;
   } elsif ($peer =~ /\%any/){
     $peer = "any";


### PR DESCRIPTION
Set correct regex to detect IKE statuses for IPv6 IPSec peers

https://phabricator.vyos.net/T3380

VyOS config:
```
set vpn ipsec esp-group grp-ESP compression 'disable'
set vpn ipsec esp-group grp-ESP lifetime '28800'
set vpn ipsec esp-group grp-ESP mode 'tunnel'
set vpn ipsec esp-group grp-ESP pfs 'dh-group14'
set vpn ipsec esp-group grp-ESP proposal 10 encryption 'aes256gcm128'
set vpn ipsec esp-group grp-ESP proposal 10 hash 'sha256'
set vpn ipsec ike-group grp-IKE dead-peer-detection action 'hold'
set vpn ipsec ike-group grp-IKE dead-peer-detection interval '30'
set vpn ipsec ike-group grp-IKE dead-peer-detection timeout '120'
set vpn ipsec ike-group grp-IKE ikev2-reauth 'no'
set vpn ipsec ike-group grp-IKE key-exchange 'ikev2'
set vpn ipsec ike-group grp-IKE lifetime '86400'
set vpn ipsec ike-group grp-IKE mobike 'disable'
set vpn ipsec ike-group grp-IKE proposal 10 dh-group '14'
set vpn ipsec ike-group grp-IKE proposal 10 encryption 'aes256gcm128'
set vpn ipsec ike-group grp-IKE proposal 10 hash 'sha256'
set vpn ipsec ipsec-interfaces interface 'eth1'
set vpn ipsec site-to-site peer dead:beef::1 authentication id 'dead:beef::2'
set vpn ipsec site-to-site peer dead:beef::1 authentication mode 'pre-shared-secret'
set vpn ipsec site-to-site peer dead:beef::1 authentication pre-shared-secret 'SSSeeccRetT'
set vpn ipsec site-to-site peer dead:beef::1 authentication remote-id 'dead:beef::1'
set vpn ipsec site-to-site peer dead:beef::1 connection-type 'initiate'
set vpn ipsec site-to-site peer dead:beef::1 ike-group 'grp-IKE'
set vpn ipsec site-to-site peer dead:beef::1 ikev2-reauth 'inherit'
set vpn ipsec site-to-site peer dead:beef::1 local-address 'dead:beef::2'
set vpn ipsec site-to-site peer dead:beef::1 tunnel 0 allow-nat-networks 'disable'
set vpn ipsec site-to-site peer dead:beef::1 tunnel 0 allow-public-networks 'disable'
set vpn ipsec site-to-site peer dead:beef::1 tunnel 0 esp-group 'grp-ESP'
set vpn ipsec site-to-site peer dead:beef::1 tunnel 0 local prefix '10.10.0.0/24'
set vpn ipsec site-to-site peer dead:beef::1 tunnel 0 remote prefix '172.16.0.0/2'

```
Show IKE (before fix, state was 'down'):
```
vyos@r4:~$ show vpn ike sa
Peer ID / IP                            Local ID / IP               
------------                            -------------
dead:beef::1                            dead:beef::2                           

    State  IKEVer  Encrypt  Hash    D-H Group      NAT-T  A-Time  L-Time
    -----  ------  -------  ----    ---------      -----  ------  ------
    up     IKEv2   aes16_256 n/a     14(MODP_2048)  no     7200    86400  

 
vyos@r4:~$ 

```
