### PR TITLE
op-vpn: T4168: Add timeout for restart vpn with nhrp

### DIFF
--- a/scripts/vyatta-vpn-op.pl
+++ b/scripts/vyatta-vpn-op.pl
@@ -65,6 +65,18 @@ if ($op eq 'clear-vpn-ipsec-process') {
           # Check if nhrp configuration exists, exit code
           # As 'restart vpn' doesn't load nhrp configuration T3846
           if (system('cli-shell-api existsActive protocols nhrp') == 0) {
+              # Set a small timeout for waiting for charon will be loaded
+              # 0 => process not found, 1 => process found
+              my $timeout = 7;
+              if (system("pgrep charon | wc -l" eq 0)) {
+                  while ($timeout >= 1){
+                    sleep(1);
+                    if (system("pgrep charon | wc -l" eq 1)){
+                      last;
+                    }
+                    $timeout--;
+                  }
+              }
               system 'sudo swanctl --load-all';
           }
   } else {


### PR DESCRIPTION
With the command "restart vpn" in some cases charon process is not
fully loaded when is used DMVPN. It is impossible to load
"swanctl -q" configuration while "charon" not loaded
Add timeout and wait until charon will be available, after that
load swanctl configuration

https://phabricator.vyos.net/T4168

It fixes such behavior:
```
vyos@VyOS-Spoke1:~$ restart vpn 
Restarting IPsec process...
connecting to 'unix:///var/run/charon.vici' failed: Connection refused
Error: connecting to 'default' URI failed: Connection refused
strongSwan 5.7.2 swanctl
```