### PR TITLE
op-mode: T4395: Extend show vpn debug for IPSec

### DIFF
--- a/templates/show/vpn/debug/node.def.in
+++ b/templates/show/vpn/debug/node.def.in
@@ -3,7 +3,7 @@ run: if [ -n "$(cli-shell-api returnActiveValues \
                   vpn ipsec ipsec-interfaces interface)" ]; then
        if pgrep charon > /dev/null
        then
-        @SUDOUSRDIR@/vyatta-vpn-op.pl --op=show-vpn-debug
+        sudo ${vyos_op_scripts_dir}/vpn_ipsec.py --action="vpn-debug"
        else
          echo IPsec process not running
        fi


### PR DESCRIPTION
Op-mode 'show vpn debug'
Old Perl code `vyatta-vpn-op.pl --op=show-vpn-debug` doesn't give
us enough debug [information](https://github.com/vyos/vyatta-op-vpn/blob/1d6006dccca4bcb341789be990e2b01b8eae94e4/scripts/vyatta-vpn-op.pl#L86-L87)
In fact it show only 'ipsec statusall'
Add python script to get all required and useful debug info

https://phabricator.vyos.net/T4395

Depends on python script PR https://github.com/vyos/vyos-1x/pull/1303