### PR TITLE
T3577: Fix permissions and template path for x509 vpn key-pair

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -22,6 +22,7 @@ cpiop = find  . ! -regex '\(.*~\|.*\.bak\|.*\.swp\|.*\#.*\#\)' -print0 | \
 
 install-exec-hook:
 	mkdir -p $(DESTDIR)${sysconfdir} $(DESTDIR)${sbindir} $(DESTDIR)$(opdir)
+	chmod +x scripts/vyatta-gen-x509-keypair
 	cp scripts/vyatta-gen-x509-keypair $(DESTDIR)${sbindir}/
 	cp scripts/key-pair.template $(DESTDIR)${sysconfdir}
 	cd templates; $(cpiop) $(DESTDIR)$(opdir)

--- a/scripts/vyatta-gen-x509-keypair.in
+++ b/scripts/vyatta-gen-x509-keypair.in
@@ -1,7 +1,7 @@
 #!/bin/bash
 CN=$1
 genkeypair (){
-  openssl req -new -nodes -keyout /config/auth/$CN.key -out /config/auth/$CN.csr -config @sysconfdir@/key-pair.template
+  openssl req -new -nodes -keyout /config/auth/$CN.key -out /config/auth/$CN.csr -config /opt/vyatta/etc/key-pair.template
 }
 if [ -f /config/auth/$CN.csr ]; then
   read -p "A certificate request named $CN.csr already exists. Overwrite (y/n)?"


### PR DESCRIPTION
https://vyos.dev/T3577

Current permission is not executable.
```
$ ls -la /opt/vyatta/sbin//vyatta-gen-x509-keypair
-rw-r--r-- 1 root root 345 May 11  2016 /opt/vyatta/sbin//vyatta-gen-x509-keypair
```
Fix template path
```
$ sudo /opt/vyatta/sbin//vyatta-gen-x509-keypair foo
Can't open /etc/key-pair.template for reading, No such file or directory
```
Expected path '/opt/vyatta/etc/key-pair.template'

Before fix:
```
vyos@r1:~$ generate vpn x509 key-pair test
sudo: /opt/vyatta/sbin//vyatta-gen-x509-keypair: command not found
vyos@r1:~$ 

chmod +x vyatta-gen-x509

vyos@r1:~$ generate vpn x509 key-pair testone
Can't open /etc/key-pair.template for reading, No such file or directory
140247622005952:error:02001002:system library:fopen:No such file or directory:../crypto/bio/bss_file.c:69:fopen('/etc/key-pair.template','r')
140247622005952:error:2006D080:BIO routines:BIO_new_file:no such file:../crypto/bio/bss_file.c:76:
vyos@r1:~$ 

```

After the fix:
```
vyos@r1:~$ generate vpn x509 key-pair testone
Generating a RSA private key
......................+++++
............+++++
writing new private key to '/config/auth/testone.key'
-----
You are about to be asked to enter information that will be incorporated
into your certificate request.
What you are about to enter is what is called a Distinguished Name or a DN.
There are quite a few fields but you can leave some blank
For some fields there will be a default value,
If you enter '.', the field will be left blank.
-----
Country Name (2 letter code) []
```