### PR TITLE
T5625: allow "restart vpn" to work when ipsec-interfaces is not set

### DIFF
--- a/templates/restart/vpn/node.def.in
+++ b/templates/restart/vpn/node.def.in
@@ -1,6 +1,5 @@
 help: Restart IPsec VPN
-run: if [ -n "$(cli-shell-api returnActiveValues \
-                  vpn ipsec ipsec-interfaces interface)" ]; then
+run: if [ -n "$(cli-shell-api returnActiveValues vpn ipsec)" ]; then
        if pgrep charon > /dev/null
        then
         @SUDOUSRDIR@/vyatta-vpn-op.pl --op=clear-vpn-ipsec-process


### PR DESCRIPTION
Right now, when `vpn ipsec ipsec-interfaces` option is not set, `run restart vpn` mistakenly believes that IPsec is not configured due to its outdated assumption that it's a required option.

This isn't a perfect fix but at least it gets rid of confusing errors when that no-longer-required option is not set. A perfect fix requires backporting the proper systemd integration.